### PR TITLE
Fix/#72 QA - 프로필 업데이트 이슈 1차 해결

### DIFF
--- a/Projects/Data/Remote/Sources/Service/UserService.swift
+++ b/Projects/Data/Remote/Sources/Service/UserService.swift
@@ -32,7 +32,7 @@ extension UserService: DependencyKey {
                 let response = await NetworkProvider.shared.sendRequest(endPoint, interceptor: interceptor)
                 
                 if case .failure(let failure) = response {
-                    throw failure
+                    throw UserClientError.duplicateNickName
                 }
             },
             

--- a/Projects/Feature/Setting/Interface/Sources/Profile/UpdateProfileFeature.swift
+++ b/Projects/Feature/Setting/Interface/Sources/Profile/UpdateProfileFeature.swift
@@ -17,35 +17,38 @@ import ComposableArchitecture
 
 @Reducer
 public struct UpdateProfileFeature: Reducer {
-    
+
     public init() {}
-    
+
     @ObservableState
     public struct State: Equatable {
-        var selectedPiece: Character = .rabbit
+        var selectedCharacter: Character = .rabbit
         var nickName: String = ""
+        var initialnickName: String = ""
+        var initialCharacter: Character = .rabbit
+
         var noticeMessage: String? = "1~6자, 한글, 영문 또는 숫자를 입력하세요."
         var isValidNickName: Bool = true
         var isAllCompleted: Bool = false // 모든 Input이 알맞게 들어갔는 지 확인
         var isUpdateSucceed: Bool = false
         var isCheckingProfile: Bool = true // 앱 초기 진입 시 API 호출
-        
+
         public init() {}
     }
-    
+
     public enum Action: BindableAction {
         case binding(BindingAction<State>)
 
         case pieceImageTapped(Character)
         case saveButtonTapped
         case backButtonTapped
-        
+
         case onAppear
-        
+
         case checkProfileResponse(Result<UserProfile, Error>)
         case updateProfileResponse(Result<Void, Error>)
     }
-    
+
     @Dependency(\.dismiss) var dismiss
     @Dependency(UserClient.self) var userClient
     @Dependency(UserService.self) var userService
@@ -64,29 +67,33 @@ public struct UpdateProfileFeature: Reducer {
             case .binding(\.nickName):
                 state.noticeMessage = "1~6자, 한글, 영문 또는 숫자를 입력하세요."
                 state.isValidNickName = self.validate(state.nickName)
-                state.isAllCompleted = state.isValidNickName && !state.nickName.isEmpty
+                state.isAllCompleted = self.isAvailableToSave(with: &state)
                 return .none
-            case .pieceImageTapped(let piece):
-                state.selectedPiece = piece
+            case .pieceImageTapped(let character):
+                state.selectedCharacter = character
+                state.isAllCompleted = self.isAvailableToSave(with: &state)
+
                 return .none
             case .backButtonTapped:
                 return .run { _ in
-                  await self.dismiss()
+                    await self.dismiss()
                 }
-                
-            // MARK: 기존 프로필 체크
+
+                // MARK: 기존 프로필 체크
             case .checkProfileResponse(.success(let userProfile)):
                 state.nickName = userProfile.nickname
-                state.selectedPiece = userProfile.character
+                state.selectedCharacter = userProfile.character
+                state.initialCharacter = userProfile.character
+                state.initialnickName = userProfile.nickname
                 state.isCheckingProfile = false
                 return .none
             case .checkProfileResponse(.failure(let error)):
                 print("🚨 에러 발생!! \(error)")
                 return .none
-            // MARK: 프로필 업데이트
+                // MARK: 프로필 업데이트
             case .saveButtonTapped:
                 let nickName = state.nickName
-                let piece = state.selectedPiece
+                let piece = state.selectedCharacter
                 return .run { send in
                     await send(.updateProfileResponse(
                         Result { try await self.userClient.createProfile(userService, nickName, piece) }
@@ -98,13 +105,14 @@ public struct UpdateProfileFeature: Reducer {
             case .updateProfileResponse(.failure(let error)):
                 guard let error = error as? UserClientError else { return .none }
                 switch error {
-                    case .duplicateNickName:
-                        state.noticeMessage = "이미 존재하는 회원 닉네임입니다."
-                        state.isValidNickName = false
-                    case .networkDisabled:
-                        print("Network 에러")
-                    default:
-                        print("에러 발생")
+                case .duplicateNickName:
+                    state.noticeMessage = "이미 존재하는 회원 닉네임입니다."
+                    state.isValidNickName = false
+                    state.isAllCompleted = false
+                case .networkDisabled:
+                    print("Network 에러")
+                default:
+                    print("에러 발생")
                 }
                 return .none
             default:
@@ -126,5 +134,11 @@ extension UpdateProfileFeature {
         guard let regex = try? NSRegularExpression(pattern: pattern) else { return false }
         let range = NSRange(location: 0, length: nickName.utf16.count)
         return regex.firstMatch(in: nickName, options: [], range: range) != nil
+    }
+
+    private func isAvailableToSave(with state: inout State) -> Bool {
+        let isCharacterEquals = state.initialCharacter == state.selectedCharacter
+        let isNicknameEquals = state.initialnickName == state.nickName
+        return state.isValidNickName && !state.nickName.isEmpty && !isNicknameEquals || state.isValidNickName && !state.nickName.isEmpty && !isCharacterEquals
     }
 }

--- a/Projects/Feature/Setting/Interface/Sources/Profile/UpdateProfileView.swift
+++ b/Projects/Feature/Setting/Interface/Sources/Profile/UpdateProfileView.swift
@@ -103,25 +103,6 @@ public struct UpdateProfileView: View {
                         Spacer()
                     }
                 }
-                
-                if showToastMessage {
-                    VStack {
-                        Spacer()
-                        HStack(alignment: .center, spacing: 10) {
-                            Image(systemName: "checkmark.circle.fill")
-                                .foregroundStyle(.green)
-                            Text("닉네임이 저장되었어요")
-                                .font(.pretendard(size: 14, type: .medium))
-                                .foregroundColor(.white)
-                        }
-                        .frame(width: 203, height: 44)
-                        .background(Color.mmGray2)
-                        .cornerRadius(9)
-                        .padding(.bottom, keyboardHeight + 111)
-                    }
-                    .transition(.opacity)
-                    .zIndex(1)
-                }
             }
         }
         .navigationBarHidden(true)
@@ -130,20 +111,6 @@ public struct UpdateProfileView: View {
         .animation(.default, value: keyboardHeight)
         .onAppear(perform: addKeyboardObserver)
         .onDisappear(perform: removeKeyboardObserver)
-        .onChange(of: store.isUpdateSucceed, { _, isUpdateSucceed in
-            if isUpdateSucceed {
-                showToastMessage = true
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                    withAnimation(.easeOut(duration: 0.5)) {
-                        showToastMessage = false
-                    }
-                    
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                        store.isUpdateSucceed = false
-                    }
-                }
-            }
-        })
         .task {
             await store
                 .send(.onAppear)

--- a/Projects/Feature/Setting/Interface/Sources/Profile/UpdateProfileView.swift
+++ b/Projects/Feature/Setting/Interface/Sources/Profile/UpdateProfileView.swift
@@ -36,7 +36,7 @@ public struct UpdateProfileView: View {
                         
                         Spacer()
                         
-                        Image(uiImage: store.selectedPiece.roundImage.image)
+                        Image(uiImage: store.selectedCharacter.roundImage.image)
                             .resizable()
                             .scaledToFit()
                             .frame(width: geometry.size.width * 0.5, height: geometry.size.height * 0.26)
@@ -51,7 +51,7 @@ public struct UpdateProfileView: View {
                                             .resizable()
                                             .scaledToFit()
                                             .frame(width: geometry.size.width * 0.26, height: geometry.size.height * 0.11)
-                                            .opacity(piece == store.selectedPiece ? 1.0 : 0.3)
+                                            .opacity(piece == store.selectedCharacter ? 1.0 : 0.3)
                                             .onTapGesture {
                                                 store.send(.pieceImageTapped(piece))
                                             }
@@ -60,7 +60,7 @@ public struct UpdateProfileView: View {
                                             .frame(width: geometry.size.width * 0.26, height: 24)
                                             .foregroundColor(.mmGray2)
                                             .background(Color.mmGray5)
-                                            .opacity(piece == store.selectedPiece ? 1.0 : 0.3)
+                                            .opacity(piece == store.selectedCharacter ? 1.0 : 0.3)
                                             .cornerRadius(20)
                                     }
                                 }

--- a/Projects/Feature/Setting/Interface/Sources/SettingFeature.swift
+++ b/Projects/Feature/Setting/Interface/Sources/SettingFeature.swift
@@ -33,6 +33,7 @@ public struct SettingFeature: Reducer {
     @ObservableState
     public struct State: Equatable {
         @Presents var destination: Destination.State?
+        var isUpdateSucceed: Bool = false
         var isNavigationPresented = false
         
         public init() {}
@@ -67,6 +68,7 @@ public struct SettingFeature: Reducer {
                 }
             case .navigateUpdateProfileViewTapped:
                 state.destination = .updateProfile(UpdateProfileFeature.State())
+                state.isUpdateSucceed = false
                 return .none
             case .navigateTermsOfUseViewTapped:
                 state.destination = .termsOfUse
@@ -79,6 +81,9 @@ public struct SettingFeature: Reducer {
                 return .none
             case .navigateProfileDeletionViewTapped:
                 state.destination = .profileDeletion(ProfileDeletionFeature.State())
+                return .none
+            case .destination(.presented(.updateProfile(.delegate(.didUpdateProfileSucceed)))):
+                state.isUpdateSucceed = true
                 return .none
             case .destination(.presented(.logout(.delegate(.didLogoutSucceed)))):
                 return .send(.delegate(.didLogout))

--- a/Projects/Feature/Setting/Interface/Sources/SettingView.swift
+++ b/Projects/Feature/Setting/Interface/Sources/SettingView.swift
@@ -12,100 +12,131 @@ import SharedDesignSystem
 import ComposableArchitecture
 
 public struct SettingView: View {
-    
+
     @Bindable var store: StoreOf<SettingFeature>
-    
+    @State private var showToastMessage = false
+
     public init(store: StoreOf<SettingFeature>) {
         self.store = store
     }
-    
+
     public var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            MMNavigationBar(
-                title: "설정"
-            ) {
-                store.send(.backButtonTapped)
-            }
-            .padding(.bottom, 22)
-            
-            ScrollView(showsIndicators: false) {
-                VStack(alignment: .leading, spacing: 0) {
-                    SettingSectionView(title: "내정보") {
-                        SettingSectionRow(
-                            title: "프로필 수정하기",
-                            item: AnyView(AnyView(Image(systemName: "chevron.right")
-                                .foregroundStyle(Color.mmDisabled))
-                            )) {
-                                store.send(.navigateUpdateProfileViewTapped)
-                            }
-                    }
-                    
-                    SettingSectionView(title: "버전정보") {
-                        SettingSectionRow(
-                            title: "현재버전",
-                            item: AnyView(Text("1.0.0")
-                                .font(.pretendard(kind: .body_xl, type: .light))
-                                .foregroundStyle(Color.mmGray1))
-                        )
-                    }
-                    
-                    SettingSectionView(title: "고객지원") {
-                        SettingSectionRow(
-                            title: "문의하기",
-                            item: AnyView(Text(verbatim: "missionmateteam@gmail.com")
-                                .font(.pretendard(kind: .body_xl, type: .light))
-                                .foregroundStyle(Color.mmGray1)
+        ZStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 0) {
+                MMNavigationBar(
+                    title: "설정"
+                ) {
+                    store.send(.backButtonTapped)
+                }
+                .padding(.bottom, 22)
+
+                ScrollView(showsIndicators: false) {
+                    VStack(alignment: .leading, spacing: 0) {
+                        SettingSectionView(title: "내정보") {
+                            SettingSectionRow(
+                                title: "프로필 수정하기",
+                                item: AnyView(AnyView(Image(systemName: "chevron.right")
+                                    .foregroundStyle(Color.mmDisabled))
+                                )) {
+                                    store.send(.navigateUpdateProfileViewTapped)
+                                }
+                        }
+
+                        SettingSectionView(title: "버전정보") {
+                            SettingSectionRow(
+                                title: "현재버전",
+                                item: AnyView(Text("1.0.0")
+                                    .font(.pretendard(kind: .body_xl, type: .light))
+                                    .foregroundStyle(Color.mmGray1))
                             )
-                        )
-                    }
-                    
-                    SettingSectionView(title: "약관 및 정책") {
-                        SettingSectionRow(
-                            title: "서비스 이용약관",
-                            item: AnyView((AnyView(Image(systemName: "chevron.right")
-                                .foregroundStyle(Color.mmDisabled))
-                            )), action: {
-                                store.send(.navigateTermsOfUseViewTapped)
-                            }
-                        )
-                        .padding(.bottom, 20)
-                        
-                        SettingSectionRow(
-                            title: "개인정보 취급 방침",
-                            item: AnyView((AnyView(Image(systemName: "chevron.right")
-                                .foregroundStyle(Color.mmDisabled))
-                            )), action: {
-                                store.send(.navigatePrivacyPolicyViewTapped)
-                            }
-                        )
-                    }
-                    
-                    SettingSectionView(title: "로그인 정보") {
-                        SettingSectionRow(
-                            title: "로그아웃",
-                            item: AnyView((AnyView(Image(systemName: "chevron.right")
-                                .foregroundStyle(Color.mmDisabled))
-                            )), action: {
-                                store.send(.navigateLogoutViewTapped)
-                            }
-                        )
-                        .padding(.bottom, 20)
-                        
-                        SettingSectionRow(
-                            title: "계정탈퇴",
-                            item: AnyView((AnyView(Image(systemName: "chevron.right")
-                                .foregroundStyle(Color.mmDisabled))
-                            )), action: {
-                                store.send(.navigateProfileDeletionViewTapped)
-                            }
-                        )
+                        }
+
+                        SettingSectionView(title: "고객지원") {
+                            SettingSectionRow(
+                                title: "문의하기",
+                                item: AnyView(Text(verbatim: "missionmateteam@gmail.com")
+                                    .font(.pretendard(kind: .body_xl, type: .light))
+                                    .foregroundStyle(Color.mmGray1)
+                                )
+                            )
+                        }
+
+                        SettingSectionView(title: "약관 및 정책") {
+                            SettingSectionRow(
+                                title: "서비스 이용약관",
+                                item: AnyView((AnyView(Image(systemName: "chevron.right")
+                                    .foregroundStyle(Color.mmDisabled))
+                                )), action: {
+                                    store.send(.navigateTermsOfUseViewTapped)
+                                }
+                            )
+                            .padding(.bottom, 20)
+
+                            SettingSectionRow(
+                                title: "개인정보 취급 방침",
+                                item: AnyView((AnyView(Image(systemName: "chevron.right")
+                                    .foregroundStyle(Color.mmDisabled))
+                                )), action: {
+                                    store.send(.navigatePrivacyPolicyViewTapped)
+                                }
+                            )
+                        }
+
+                        SettingSectionView(title: "로그인 정보") {
+                            SettingSectionRow(
+                                title: "로그아웃",
+                                item: AnyView((AnyView(Image(systemName: "chevron.right")
+                                    .foregroundStyle(Color.mmDisabled))
+                                )), action: {
+                                    store.send(.navigateLogoutViewTapped)
+                                }
+                            )
+                            .padding(.bottom, 20)
+
+                            SettingSectionRow(
+                                title: "계정탈퇴",
+                                item: AnyView((AnyView(Image(systemName: "chevron.right")
+                                    .foregroundStyle(Color.mmDisabled))
+                                )), action: {
+                                    store.send(.navigateProfileDeletionViewTapped)
+                                }
+                            )
+                        }
                     }
                 }
+            }
+            if showToastMessage {
+                VStack {
+                    Spacer()
+                    HStack(alignment: .center, spacing: 10) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                        Text("닉네임이 저장되었어요")
+                            .font(.pretendard(size: 14, type: .medium))
+                            .foregroundColor(.white)
+                    }
+                    .frame(width: 203, height: 44)
+                    .background(Color.mmGray2)
+                    .cornerRadius(9)
+                    .padding(.bottom, 111)
+                }
+                .transition(.opacity)
+                .zIndex(1)
             }
         }
         .navigationBarHidden(true)
         .edgesIgnoringSafeArea(.bottom)
         .padding(.horizontal, 24)
+        .onChange(of: store.isUpdateSucceed, { _, isUpdated in
+            if isUpdated {
+                showToastMessage = true
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                    withAnimation(.easeOut(duration: 0.5)) {
+                        showToastMessage = false
+                    }
+                }
+            }
+        })
         .overlay {
             if let store = store.scope(state: \.destination?.logout, action: \.destination.logout) {
                 LogoutConfirmView(store: store)
@@ -135,15 +166,15 @@ public struct SettingView: View {
 }
 
 struct SettingSectionView<Content: View>: View {
-    
+
     private let title: String
     private let content: Content
-    
+
     public init(title: String, @ViewBuilder content: () -> Content) {
         self.title = title
         self.content = content()
     }
-    
+
     public var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text(title)
@@ -151,14 +182,14 @@ struct SettingSectionView<Content: View>: View {
                 .foregroundStyle(Color.mmGray3)
                 .padding(.bottom, 20)
                 .padding(.top, 18)
-            
+
             content
                 .padding(.bottom, 16)
-            
+
             Divider()
         }
         .padding(.bottom, 10)
-        
+
     }
 }
 
@@ -167,13 +198,13 @@ public struct SettingSectionRow: View {
     private var title: String
     private var item: AnyView
     private var action: (() -> Void)?
-    
+
     public init(title: String, item: AnyView, action: (() -> Void)? = nil) {
         self.title = title
         self.item = item
         self.action = action
     }
-    
+
     public var body: some View {
         Group {
             if let action = action {
@@ -185,15 +216,15 @@ public struct SettingSectionRow: View {
             }
         }
     }
-    
+
     private var rowContent: some View {
         HStack(spacing: 0) {
             Text(title)
                 .font(.pretendard(kind: .body_xl, type: .light))
                 .foregroundStyle(Color.mmGray1)
-            
+
             Spacer()
-            
+
             item
         }
     }


### PR DESCRIPTION
### 🏗️ 구현사항
- 프로필 업데이트 이슈 부분 해결
  - 캐릭터만 바꿔도 저장하기 버튼이 활성화되어야함
  - 중복된 닉네이이면 에러 상태가 떠야함
  - 프로필 수정이 완료되면 Dismiss하고 토스트 띄우기




### 🚨 중점적으로 봐줬으면 좋겠는 점
- 현재 프로필 생성과 프로필 업데이트 API를 동일하게 가져가서 생기는 이슈가 있어요. 요거랑 다른 프로필 업데이트 이슈들은 2차 해결로 넘겨서 끝내겠습니다!



### ✅ 체크사항





 ---------
- Resolved: #72 
