### PR TITLE
Fix/#77 프로필 관련 QA 수정사항 반영

### DIFF
--- a/Projects/Data/Remote/Interface/Sources/Service/UserService.swift
+++ b/Projects/Data/Remote/Interface/Sources/Service/UserService.swift
@@ -11,12 +11,12 @@ import DomainUserInterface
 
 public struct UserService: UserServiceable {
 
-    public var createProfile: @Sendable (_ nickName: String, DomainUserInterface.Character) async throws -> Void
+    public var createProfile: @Sendable (_ nickName: String?, DomainUserInterface.Character) async throws -> Void
     public var deleteProfile: @Sendable () async throws -> Void
     public var checkProfile: @Sendable () async throws -> UserProfile
 
     public init(
-        createProfile: @escaping @Sendable (_ nickName: String, DomainUserInterface.Character) async throws -> Void,
+        createProfile: @escaping @Sendable (_ nickName: String?, DomainUserInterface.Character) async throws -> Void,
         deleteProfile: @escaping @Sendable () async throws -> Void,
         checkProfile: @escaping @Sendable () async throws -> UserProfile
     ) {

--- a/Projects/Data/Remote/Sources/DTO/Request/CreateProfileRequestDTO.swift
+++ b/Projects/Data/Remote/Sources/DTO/Request/CreateProfileRequestDTO.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 struct CreatProfileRequestDTO: Encodable {
-    let nickname: String
+    let nickname: String?
     let characterType: String
 
-    init(nickname: String, characterType: String) {
+    init(nickname: String?, characterType: String) {
         self.nickname = nickname
         self.characterType = characterType
     }

--- a/Projects/Data/Remote/Sources/Service/UserService.swift
+++ b/Projects/Data/Remote/Sources/Service/UserService.swift
@@ -28,9 +28,9 @@ extension UserService: DependencyKey {
                     httpMethod: .patch,
                     bodyParameters: requestDTO
                 )
-                
+
                 let response = await NetworkProvider.shared.sendRequest(endPoint, interceptor: interceptor)
-                
+
                 if case .failure(let failure) = response {
                     throw UserClientError.duplicateNickName
                 }

--- a/Projects/Domain/User/Interface/Sources/Character.swift
+++ b/Projects/Domain/User/Interface/Sources/Character.swift
@@ -14,8 +14,8 @@ public enum Character: String, CaseIterable {
     case rabbit = "RABBIT"
     case cat = "CAT"
     case dog = "DOG"
-    case bird = "BIRD"
     case panda = "PANDA"
+    case bird = "BIRD"
     case bear = "BEAR"
     
     public init?(rawValue: String) {

--- a/Projects/Domain/User/Interface/Sources/Serviceable/UserServiceable.swift
+++ b/Projects/Domain/User/Interface/Sources/Serviceable/UserServiceable.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public protocol UserServiceable {
 
-    var createProfile: @Sendable (_ nickName: String, Character) async throws -> Void { get }
+    var createProfile: @Sendable (_ nickName: String?, Character) async throws -> Void { get }
     var deleteProfile: @Sendable () async throws -> Void { get }
     var checkProfile: @Sendable () async throws -> UserProfile { get }
 }

--- a/Projects/Domain/User/Interface/Sources/UserClient.swift
+++ b/Projects/Domain/User/Interface/Sources/UserClient.swift
@@ -17,7 +17,7 @@ public enum UserClientError: Error {
 
 public struct UserClient {
 
-    public typealias Nickname = String
+    public typealias Nickname = String?
 
     public var createProfile: @Sendable (_ userService: UserServiceable, Nickname, Character) async throws -> Void
     public var deleteProfile: @Sendable (_ userService: UserServiceable) async throws -> Void

--- a/Projects/Feature/Entrance/Interface/Sources/Entrance/EntranceFeature.swift
+++ b/Projects/Feature/Entrance/Interface/Sources/Entrance/EntranceFeature.swift
@@ -88,6 +88,7 @@ public struct EntranceFeature: Reducer {
                 
                 if state.isFirstEntrance {
                     state.pieceCreationCompleted = PieceCreationCompletedFeature.State(userProfile: userProfile)
+                    state.isFirstEntrance = false
                 }
                 return .none
             case .checkProfileResponse(.failure(let error)):

--- a/Projects/Feature/Entrance/Interface/Sources/Entrance/EntranceView.swift
+++ b/Projects/Feature/Entrance/Interface/Sources/Entrance/EntranceView.swift
@@ -102,6 +102,11 @@ public struct EntranceView: View {
             }
             .edgesIgnoringSafeArea(.bottom)
             .edgesIgnoringSafeArea(.horizontal)
+            .task {
+                await store
+                    .send(.onAppear)
+                    .finish()
+            }
         } destination: { store in
             switch store.case {
             case let .missionContentSetting(store):
@@ -120,11 +125,6 @@ public struct EntranceView: View {
             if let store = store.scope(state: \.pieceCreationCompleted, action: \.pieceCreationCompleted.presented) {
                 PieceCreationCompletedView(store: store)
             }
-        }
-        .task {
-            await store
-                .send(.onAppear)
-                .finish()
         }
     }
     

--- a/Projects/Feature/PieceCreation/Interface/Sources/PieceCreationView.swift
+++ b/Projects/Feature/PieceCreation/Interface/Sources/PieceCreationView.swift
@@ -37,29 +37,35 @@ public struct PieceCreationView: View {
                 Image(uiImage: store.selectedPiece.roundImage.image)
                     .resizable()
                     .scaledToFit()
-                    .frame(width: geometry.size.width * 0.5, height: geometry.size.height * 0.26)
+                    .frame(width: geometry.size.width * 0.56)
                     .padding(.bottom, 18)
                 
                 ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 8) {
-                        Spacer().frame(width: 16)
-                        ForEach(Character.allCases, id: \.self) { piece in
-                            VStack {
-                                Image(uiImage: piece.basicImage.image)
-                                    .resizable()
-                                    .scaledToFit()
-                                    .frame(width: geometry.size.width * 0.26, height: geometry.size.height * 0.11)
-                                    .opacity(piece == store.selectedPiece ? 1.0 : 0.3)
-                                    .onTapGesture {
-                                        store.send(.pieceImageTapped(piece))
-                                    }
-                                Text(piece.koreanName)
-                                    .font(.pretendard(kind: .body_md, type:.bold))
-                                    .frame(width: geometry.size.width * 0.26, height: 24)
-                                    .foregroundColor(.mmGray2)
-                                    .background(Color.mmGray5)
-                                    .opacity(piece == store.selectedPiece ? 1.0 : 0.3)
-                                    .cornerRadius(20)
+                    ScrollViewReader { proxy in
+                        HStack(spacing: 8) {
+                            Spacer().frame(width: 16)
+                            ForEach(Character.allCases, id: \.self) { piece in
+                                VStack {
+                                    Image(uiImage: piece.basicImage.image)
+                                        .resizable()
+                                        .scaledToFit()
+                                        .frame(width: geometry.size.width * 0.26, height: geometry.size.height * 0.11)
+                                        .opacity(piece == store.selectedPiece ? 1.0 : 0.3)
+                                        .onTapGesture {
+                                            store.send(.pieceImageTapped(piece))
+                                            withAnimation {
+                                                proxy.scrollTo(piece, anchor: .center)
+                                            }
+                                        }
+                                        .id(piece)
+                                    Text(piece.koreanName)
+                                        .font(.pretendard(kind: .body_md, type:.bold))
+                                        .frame(width: geometry.size.width * 0.26, height: 24)
+                                        .foregroundColor(.mmGray2)
+                                        .background(Color.mmGray5)
+                                        .opacity(piece == store.selectedPiece ? 1.0 : 0.3)
+                                        .cornerRadius(20)
+                                }
                             }
                         }
                     }

--- a/Projects/Feature/Setting/Interface/Sources/Profile/UnsavedChangesAlert/UnsavedChangesAlertFeature.swift
+++ b/Projects/Feature/Setting/Interface/Sources/Profile/UnsavedChangesAlert/UnsavedChangesAlertFeature.swift
@@ -32,7 +32,6 @@ public struct UnsavedChangesAlertFeature: Reducer {
         }
 
         case delegate(Delegate)
-
     }
 
     @Dependency(\.dismiss) var dismiss
@@ -42,13 +41,11 @@ public struct UnsavedChangesAlertFeature: Reducer {
             print(action)
             switch action {
             case .exitButtonTapped:
-                print("모지?....!!!!")
                 return .run { send in
                     await send(.delegate(.exit))
                     await self.dismiss()
                 }
             case .cancelButtonTapped:
-                print("모지?....")
                 return .run { _ in
                   await self.dismiss()
                 }

--- a/Projects/Feature/Setting/Interface/Sources/Profile/UnsavedChangesAlert/UnsavedChangesAlertFeature.swift
+++ b/Projects/Feature/Setting/Interface/Sources/Profile/UnsavedChangesAlert/UnsavedChangesAlertFeature.swift
@@ -1,0 +1,60 @@
+//
+//  UnsavedChangesAlertFeature.swift
+//  FeatureSetting
+//
+//  Created by Miro on 10/30/24.
+//
+
+import Foundation
+
+import DomainUser
+import DomainUserInterface
+import DataRemote
+import DataRemoteInterface
+import CoreKeychainInterface
+
+import ComposableArchitecture
+
+@Reducer
+public struct UnsavedChangesAlertFeature: Reducer {
+
+    @ObservableState
+    public struct State: Equatable {
+        public init() {}
+    }
+
+    public enum Action {
+        case exitButtonTapped
+        case cancelButtonTapped
+
+        public enum Delegate {
+            case exit
+        }
+
+        case delegate(Delegate)
+
+    }
+
+    @Dependency(\.dismiss) var dismiss
+
+    public var body: some ReducerOf<Self> {
+        Reduce<State, Action> { state, action in
+            print(action)
+            switch action {
+            case .exitButtonTapped:
+                print("모지?....!!!!")
+                return .run { send in
+                    await send(.delegate(.exit))
+                    await self.dismiss()
+                }
+            case .cancelButtonTapped:
+                print("모지?....")
+                return .run { _ in
+                  await self.dismiss()
+                }
+            default:
+                return .none
+            }
+        }
+    }
+}

--- a/Projects/Feature/Setting/Interface/Sources/Profile/UnsavedChangesAlert/UnsavedChangesAlertView.swift
+++ b/Projects/Feature/Setting/Interface/Sources/Profile/UnsavedChangesAlert/UnsavedChangesAlertView.swift
@@ -1,0 +1,53 @@
+//
+//  UnsavedChangesAlertView.swift
+//  FeatureSetting
+//
+//  Created by Miro on 10/30/24.
+//
+
+import SwiftUI
+
+import SharedDesignSystem
+
+import ComposableArchitecture
+
+public struct UnsavedChangesAlertView: View {
+
+    @Bindable public var store: StoreOf<UnsavedChangesAlertFeature>
+    @State private var scale = 0.5
+
+    public init(store: StoreOf<UnsavedChangesAlertFeature>) {
+        self.store = store
+    }
+
+    public var body: some View {
+        ZStack {
+            Color.mmBlack
+                .opacity(0.7)
+                .edgesIgnoringSafeArea(.all)
+            VStack {
+                Spacer()
+                MMPopUpView(
+                    title: "아직 수정중이에요\n이대로 나가시나요?",
+                    subtitle: "나가면 캐릭터 수정이 반영되지 않아요",
+                    content: {
+                        EmptyView()
+                    },
+                    primaryButtonTitle: "나가기",
+                    primaryButtonAction: {
+                        store.send(.exitButtonTapped)
+                    },
+                    secondaryButtonTitle: "계속 작성하기") {
+                        store.send(.cancelButtonTapped)
+                    }
+                    .padding(.horizontal, 24)
+                Spacer()
+            }
+            .scaleEffect(scale)
+            .animate(using: .spring(response: 0.3, dampingFraction: 0.8, blendDuration: 0)) {
+                scale = 1.0
+            }
+        }
+        .ignoresSafeArea(.all)
+    }
+}

--- a/Projects/Feature/Setting/Interface/Sources/Profile/UpdateProfileFeature.swift
+++ b/Projects/Feature/Setting/Interface/Sources/Profile/UpdateProfileFeature.swift
@@ -98,7 +98,7 @@ public struct UpdateProfileFeature: Reducer {
                 return .none
                 // MARK: 프로필 업데이트
             case .saveButtonTapped:
-                let nickName = state.nickName
+                let nickName = (state.nickName == state.initialNickName) ? nil : state.nickName
                 let piece = state.selectedCharacter
                 return .run { send in
                     await send(.updateProfileResponse(

--- a/Projects/Feature/Setting/Interface/Sources/Profile/UpdateProfileFeature.swift
+++ b/Projects/Feature/Setting/Interface/Sources/Profile/UpdateProfileFeature.swift
@@ -22,7 +22,9 @@ public struct UpdateProfileFeature: Reducer {
 
     @ObservableState
     public struct State: Equatable {
-        var selectedCharacter: Character = .rabbit
+        @Presents var unsavedChanges: UnsavedChangesAlertFeature.State?
+
+        var selectedCharacter: Character? = nil
         var nickName: String = ""
         var initialNickName: String = ""
         var initialCharacter: Character = .rabbit
@@ -37,6 +39,7 @@ public struct UpdateProfileFeature: Reducer {
 
     public enum Action: BindableAction {
         case binding(BindingAction<State>)
+        case unsavedChanges(PresentationAction<UnsavedChangesAlertFeature.Action>)
 
         case pieceImageTapped(Character)
         case saveButtonTapped
@@ -81,6 +84,15 @@ public struct UpdateProfileFeature: Reducer {
 
                 return .none
             case .backButtonTapped:
+                let hasInput = state.nickName != "" || state.selectedCharacter != nil
+                let hasChanges = state.nickName != state.initialNickName ||
+                                 state.selectedCharacter != state.initialCharacter
+
+                if hasInput && hasChanges {
+                    state.unsavedChanges = UnsavedChangesAlertFeature.State()
+                    return .none
+                }
+
                 return .run { _ in
                     await self.dismiss()
                 }
@@ -102,7 +114,7 @@ public struct UpdateProfileFeature: Reducer {
                 let piece = state.selectedCharacter
                 return .run { send in
                     await send(.updateProfileResponse(
-                        Result { try await self.userClient.createProfile(userService, nickName, piece) }
+                        Result { try await self.userClient.createProfile(userService, nickName, piece ?? .rabbit) }
                     ))
                 }
             case .updateProfileResponse(.success(_)):
@@ -123,9 +135,16 @@ public struct UpdateProfileFeature: Reducer {
                     print("에러 발생")
                 }
                 return .none
+            case .unsavedChanges(.presented(.delegate(.exit))):
+                return .run { _ in
+                    await self.dismiss()
+                }
             default:
                 return .none
             }
+        }
+        .ifLet(\.$unsavedChanges, action: \.unsavedChanges) {
+            UnsavedChangesAlertFeature()
         }
     }
 }

--- a/Projects/Feature/Setting/Interface/Sources/Profile/UpdateProfileView.swift
+++ b/Projects/Feature/Setting/Interface/Sources/Profile/UpdateProfileView.swift
@@ -72,6 +72,11 @@ public struct UpdateProfileView: View {
                                     }
                                 }
                                 .padding(.bottom, 38)
+                                .onAppear {
+                                    withAnimation {
+                                        proxy.scrollTo(store.initialCharacter, anchor: .center)
+                                    }
+                                }
                             }
                         }
                         

--- a/Projects/Feature/Setting/Interface/Sources/Profile/UpdateProfileView.swift
+++ b/Projects/Feature/Setting/Interface/Sources/Profile/UpdateProfileView.swift
@@ -29,43 +29,50 @@ public struct UpdateProfileView: View {
                     VStack(spacing: 0) {
                         Spacer()
                             .frame(height: 48)
-                        
+
                         Text("프로필 수정")
                             .font(.pretendard(kind: .heading_sm, type: .bold))
                             .foregroundColor(.mmGray1)
-                        
+
                         Spacer()
-                        
+
                         Image(uiImage: store.selectedCharacter.roundImage.image)
                             .resizable()
                             .scaledToFit()
-                            .frame(width: geometry.size.width * 0.5, height: geometry.size.height * 0.26)
-                            .padding(.bottom, 18)
-                        
+                            .frame(width: geometry.size.width * 0.41)
+
+                        Spacer()
+
                         ScrollView(.horizontal, showsIndicators: false) {
-                            HStack(spacing: 8) {
-                                Spacer().frame(width: 16)
-                                ForEach(Character.allCases, id: \.self) { piece in
-                                    VStack {
-                                        Image(uiImage: piece.basicImage.image)
-                                            .resizable()
-                                            .scaledToFit()
-                                            .frame(width: geometry.size.width * 0.26, height: geometry.size.height * 0.11)
-                                            .opacity(piece == store.selectedCharacter ? 1.0 : 0.3)
-                                            .onTapGesture {
-                                                store.send(.pieceImageTapped(piece))
-                                            }
-                                        Text(piece.koreanName)
-                                            .font(.pretendard(kind: .body_md, type:.bold))
-                                            .frame(width: geometry.size.width * 0.26, height: 24)
-                                            .foregroundColor(.mmGray2)
-                                            .background(Color.mmGray5)
-                                            .opacity(piece == store.selectedCharacter ? 1.0 : 0.3)
-                                            .cornerRadius(20)
+                            ScrollViewReader { proxy in
+                                HStack(spacing: 8) {
+                                    Spacer().frame(width: 16)
+                                    ForEach(Character.allCases, id: \.self) { piece in
+                                        VStack {
+                                            Image(uiImage: piece.basicImage.image)
+                                                .resizable()
+                                                .scaledToFit()
+                                                .frame(width: geometry.size.width * 0.26, height: geometry.size.height * 0.11)
+                                                .opacity(piece == store.selectedCharacter ? 1.0 : 0.3)
+                                                .onTapGesture {
+                                                    store.send(.pieceImageTapped(piece))
+                                                    withAnimation {
+                                                        proxy.scrollTo(piece, anchor: .center)
+                                                    }
+                                                }
+                                                .id(piece)
+                                            Text(piece.koreanName)
+                                                .font(.pretendard(kind: .body_md, type:.bold))
+                                                .frame(width: geometry.size.width * 0.26, height: 24)
+                                                .foregroundColor(.mmGray2)
+                                                .background(Color.mmGray5)
+                                                .opacity(piece == store.selectedCharacter ? 1.0 : 0.3)
+                                                .cornerRadius(20)
+                                        }
                                     }
                                 }
+                                .padding(.bottom, 38)
                             }
-                            .padding(.bottom, 38)
                         }
                         
                         MMTextField(

--- a/Projects/Feature/Setting/Interface/Sources/Profile/UpdateProfileView.swift
+++ b/Projects/Feature/Setting/Interface/Sources/Profile/UpdateProfileView.swift
@@ -36,7 +36,7 @@ public struct UpdateProfileView: View {
 
                         Spacer()
 
-                        Image(uiImage: store.selectedCharacter.roundImage.image)
+                        Image(uiImage: store.selectedCharacter?.roundImage.image ?? store.initialCharacter.roundImage.image)
                             .resizable()
                             .scaledToFit()
                             .frame(width: geometry.size.width * 0.41)
@@ -122,6 +122,11 @@ public struct UpdateProfileView: View {
             await store
                 .send(.onAppear)
                 .finish()
+        }
+        .overlay {
+            if let store = store.scope(state: \.unsavedChanges, action: \.unsavedChanges.presented) {
+                UnsavedChangesAlertView(store: store)
+            }
         }
     }
 }


### PR DESCRIPTION
### 🏗️ 구현사항
- 프로필 선택시 해당 프로필이 가운데 위치하도록 자동 이동
- 이미지 사이즈 설정
- 캐릭터만 바꿔도 저장하기 버튼이 활성화되어야함
- 캐릭터 수정할 때도 저장되었다는 토스트가 떠야함
- 중복된 닉네임이면 에러 상태여야함
- 프로필 수정 나가고 토스트 띄우기
- 저장하기 버튼 누르고 밖으로 나가져야함
- 장기말, 닉네임 둘 중 하나만 바꾸는 거 가능해야함
- 수정 후 entrance에서도 바뀌게 구현하기
- 장기말 선택 시 알아서 스크롤 되게 구현


### 🚨 중점적으로 봐줬으면 좋겠는 점
- entrance에서 setting으로 갔을 때 캐릭터를 수정하고 다시 돌아왔을 때 변경된 캐릭터가 보여야해서 다시 한번 fetching해오도록 구현했어요. 근데 매번 onAppear할 때마다 받아오니까 캐릭터를 수정하지 않을 때도 다시 API 호출을 하는 부분이 맘에 안드는데 혹시 더 좋은 방법이 뭐가 있을까요?(캐릭터를 수정했을 때만 delegate으로 다시 API 호출하기?..) 



### ✅ 스크린샷
| 프로필 수정 | 첫 프로필 설정 |
| ----- | ----- |
|<img src="https://github.com/user-attachments/assets/02934005-d8fc-4f76-b0e7-bb5991938259" width = "200"/>|<img src="https://github.com/user-attachments/assets/700e7142-59c1-48e0-8045-0c6a0d07b64f" width = "200"/>|





 ---------
- Resolved: #77 
