### PR TITLE
fix: 이미지 업로드 화면이 깨지는 이슈 해결

### DIFF
--- a/Projects/Feature/Home/Interface/Sources/ImageUpload/ImageUploadView.swift
+++ b/Projects/Feature/Home/Interface/Sources/ImageUpload/ImageUploadView.swift
@@ -10,6 +10,7 @@ import SharedDesignSystem
 import ComposableArchitecture
 
 public struct ImageUploadView: View {
+    @Environment(\.safeAreaInsets) var safeAreaInsets: UIEdgeInsets
     
     let store: StoreOf<ImageUploadFeature>
     
@@ -20,7 +21,7 @@ public struct ImageUploadView: View {
     public var body: some View {
         ZStack(alignment: .bottom) {
             ZStack(alignment: .top) {
-                SharedDesignSystemAsset.Colors.white.swiftUIColor
+                Color.clear
                     .edgesIgnoringSafeArea(.all)
                     .overlay {
                         Image(uiImage: store.selectedImage)
@@ -67,6 +68,7 @@ public struct ImageUploadView: View {
                 .padding(.top, 14)
                 .padding(.horizontal, 24)
             }
+            .padding(.top, safeAreaInsets.top)
             Button(action: {
                 store.send(.didTapUploadButton)
             }) {
@@ -79,6 +81,8 @@ public struct ImageUploadView: View {
                     .cornerRadius(30)
             }
             .padding(.horizontal, 24)
+            .padding(.bottom, safeAreaInsets.bottom)
         }
+        .background(SharedDesignSystemAsset.Colors.white.swiftUIColor)
     }
 }

--- a/Projects/Shared/Util/Sources/Extensions/EnvironmentValues+.swift
+++ b/Projects/Shared/Util/Sources/Extensions/EnvironmentValues+.swift
@@ -1,0 +1,18 @@
+//
+//  EnvironmentValues+.swift
+//  SharedUtil
+//
+//  Created by Haeseok Lee on 11/7/24.
+//
+
+import SwiftUI
+
+extension EnvironmentValues {
+    @Entry public var safeAreaInsets: UIEdgeInsets = {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }?
+            .safeAreaInsets ?? .zero
+    }()
+}


### PR DESCRIPTION
### 🏗️ 구현사항

이미지 업로드 화면이 깨지는 이슈를 해결했습니다



### 🚨 중점적으로 봐줬으면 좋겠는 점

* `@Entry` 매크로로 커스텀 safeAreaInsets Environment를 만들어봤습니다



### ✅ 체크사항


| <img src="https://github.com/user-attachments/assets/9eb26478-0094-4cf2-a94c-a948d7e4232b" width="300"> |
| - |


 ---------
- Resolved: #83 
