### PR TITLE
feature: 탭 가능한 보드블록만 터치하도록 수정

### DIFF
--- a/Projects/Feature/Home/Interface/Sources/Home/HomeFeature.swift
+++ b/Projects/Feature/Home/Interface/Sources/Home/HomeFeature.swift
@@ -226,6 +226,8 @@ public struct HomeFeature {
                 return .none
                 
             case let .didTapBlock(position):
+                guard let myPosition = state.competition?.myPiece?.position,
+                    checkIsTappable(position: position, with: myPosition) else { return .none }
                 state.isLoading = true
                 return .run { [mission = state.mission] send in
                     await send(.didFetchVerificationInfo(
@@ -335,6 +337,13 @@ public struct HomeFeature {
     }
     
     public init() {}
+}
+
+private extension HomeFeature {
+    
+    func checkIsTappable(position: Position, with myPosition: Position) -> Bool {
+        position.index != .zero && position.index <= myPosition.index
+    }
 }
 
 public extension HomeFeature {


### PR DESCRIPTION
### 🏗️ 구현사항

탭 가능한 보드 블록만 유저가 터치하다록 수정했습니다



### 🚨 중점적으로 봐줬으면 좋겠는 점

유저가 터치한 블록이 첫번째 인덱스의 블록이 아니고, 현재 장기말이 위치한 인덱스보다 같거나 작으면 터치가능하도록 했습니다


### ✅ 체크사항





 ---------
- Resolved: 
