### PR TITLE
feature: 미션상태 클라 -> 서버 api로 마이그레이션 / Story뷰 순서 서버순서로 변경

### DIFF
--- a/Projects/Data/Remote/Interface/Sources/Service/MissionMemberService.swift
+++ b/Projects/Data/Remote/Interface/Sources/Service/MissionMemberService.swift
@@ -14,11 +14,15 @@ public struct MissionMemberService: MissionMemberServiceable {
 
     public var getMissionMembersRank: @Sendable (Int) async throws -> MissionRank
     
+    public var completeMission: @Sendable (Int) async throws -> Void
+    
     public init(
         getMissionMembersMe: @escaping @Sendable () async throws -> MyMissionInfo,
-        getMissionMembersRank: @escaping @Sendable (Int) async throws -> MissionRank
+        getMissionMembersRank: @escaping @Sendable (Int) async throws -> MissionRank,
+        completeMission: @escaping @Sendable (Int) async throws -> Void
     ) {
         self.getMissionMembersMe = getMissionMembersMe
         self.getMissionMembersRank = getMissionMembersRank
+        self.completeMission = completeMission
     }
 }

--- a/Projects/Data/Remote/Sources/DTO/Request/CompleteMissionRequestDTO.swift
+++ b/Projects/Data/Remote/Sources/DTO/Request/CompleteMissionRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  CompleteMissionDTO.swift
+//  DataRemote
+//
+//  Created by Haeseok Lee on 11/15/24.
+//
+
+import Foundation
+
+struct CompleteMissionRequestDTO: Encodable {
+    let missionId: Int
+}

--- a/Projects/Data/Remote/Sources/DTO/Response/GetMissionMembersMeResponseDTO.swift
+++ b/Projects/Data/Remote/Sources/DTO/Response/GetMissionMembersMeResponseDTO.swift
@@ -17,6 +17,7 @@ struct GetMissionMembersMeResponseDTO: Decodable {
     struct Mission: Decodable {
         let missionId: Int
         let description: String
+        let missionStatus: String
     }
     
     let profile: Profile

--- a/Projects/Data/Remote/Sources/Service/MissionMemberService.swift
+++ b/Projects/Data/Remote/Sources/Service/MissionMemberService.swift
@@ -49,6 +49,19 @@ extension MissionMemberService: DependencyKey {
                 case .failure(let error):
                     throw error
                 }
+            },
+            completeMission: { missionId in
+                let endPoint = Endpoint<Empty>(
+                    path: "api/mission-members/complete",
+                    httpMethod: .post,
+                    bodyParameters: CompleteMissionRequestDTO(missionId: missionId)
+                )
+                
+                let response = await NetworkProvider.shared.sendRequest(endPoint, interceptor: authIntercepter)
+                
+                if case .failure(let failure) = response {
+                    throw failure
+                }
             }
         )
     }()
@@ -67,7 +80,7 @@ extension GetMissionMembersMeResponseDTO {
         .init(
             profile: .init(nickname: profile.nickname, characterType: profile.characterType),
             missions: missions.map {
-                .init(missionId: $0.missionId, description: $0.description)
+                .init(missionId: $0.missionId, description: $0.description, missionStatus: $0.missionStatus)
             }
         )
     }

--- a/Projects/Domain/Board/Interface/Sources/Serviceable/MissionBoardServiceable.swift
+++ b/Projects/Domain/Board/Interface/Sources/Serviceable/MissionBoardServiceable.swift
@@ -38,6 +38,7 @@ public struct MissionBoard {
     
     public let missionBoards: [BoardInfo]
     public let progressCount: Int
+    public var isEmpty: Bool { missionBoards.flatMap(\.missionBoardMembers).isEmpty }
     
     public init(missionBoards: [BoardInfo], progressCount: Int) {
         self.missionBoards = missionBoards

--- a/Projects/Domain/Competition/Interface/Sources/Competition.swift
+++ b/Projects/Domain/Competition/Interface/Sources/Competition.swift
@@ -16,8 +16,6 @@ public struct Competition {
     
     public var verifications: [Vertification]
     
-    public var state: State
-    
     public var info: [InfoKey: String]
     
     public var board: Board
@@ -26,14 +24,12 @@ public struct Competition {
         players: [Player],
         verifications: [Vertification],
         board: Board,
-        info: [InfoKey: String] = [:],
-        state: State
+        info: [InfoKey: String] = [:]
     ) {
         self.players = players
         self.verifications = verifications
         self.board = board
         self.info = info
-        self.state = state
         self.board.update(pieces: createPieces(by: players))
     }
     
@@ -96,13 +92,6 @@ public struct Competition {
 
 public extension Competition {
     
-    enum State: Equatable {
-        case notStarted(hasOtherPlayer: Bool)
-        case started
-        case disabled
-        case finished
-    }
-    
     enum InfoKey {
         case title
         case subtitle
@@ -111,35 +100,16 @@ public extension Competition {
 
 public extension Mission {
     
-    func competitionState(hasOtherPlayers: Bool) -> Competition.State {
-        if endDate <= Date.now {
-            return .finished
-        }
-        if startDate <= Date.now, hasOtherPlayers == false {
-            return .disabled
-        }
-        if startDate <= Date.now, hasOtherPlayers == true {
-            return .started
-        }
-        if startDate > Date.now, hasOtherPlayers == false {
-            return .notStarted(hasOtherPlayer: false)
-        }
-        if startDate > Date.now, hasOtherPlayers == true {
-            return .notStarted(hasOtherPlayer: true)
-        }
-        return .disabled
-    }
-    
-    func makeInfos(competitionState state: Competition.State, progressCount: Int, myRank: Int) -> [Competition.InfoKey: String] {
-        switch state {
-        case .notStarted, .disabled, .finished:
+    func makeInfos(missionStatus: MissionStatus, progressCount: Int, myRank: Int) -> [Competition.InfoKey: String] {
+        switch missionStatus {
+        case .pending, .created, .canceled, .deleted:
             let formatter = DateFormatter()
             formatter.dateFormat = "경쟁시작 M월 d일"
             return [
                 .title: formatter.string(from: startDate),
                 .subtitle: "해당일에 자동으로 경쟁이 시작돼요."
             ]
-        case .started:
+        case .ongoing, .inProgress, .pendingCompletion, .completed:
             if !checkIsMissionDay || !checkIsMissionTime {
                 return [
                     .title: "꾸준하게 완수해봐요!",

--- a/Projects/Domain/Competition/Interface/Sources/Competition.swift
+++ b/Projects/Domain/Competition/Interface/Sources/Competition.swift
@@ -14,6 +14,12 @@ public struct Competition {
     
     public var players: [Player]
     
+    public var sortedPlayersByVerification: [Player] {
+        verifications.compactMap { verfication in
+            players.first(where: { $0.id == verfication.playerID })
+        }
+    }
+    
     public var verifications: [Vertification]
     
     public var info: [InfoKey: String]
@@ -57,20 +63,6 @@ public struct Competition {
             return myPiece
         }
         return result.first
-    }
-    
-    public mutating func sortPlayersByVerifiedAt() {
-        players = players.sorted(by: { lhs, rhs in
-            guard let lhsResult = findVerification(by: lhs.id)?.verifiedAt,
-                  let rhsResult = findVerification(by: rhs.id)?.verifiedAt else { return false }
-            return lhsResult > rhsResult
-        })
-    }
-    
-    public mutating func moveMeToFront() {
-        guard let meIndex = players.firstIndex(where: { $0.isMe }) else { return }
-        let me = players.remove(at: meIndex)
-        players.insert(me, at: .zero)
     }
     
     public mutating func createPieces(by players: [Player]) -> [Position: [Piece]] {

--- a/Projects/Domain/Competition/Interface/Sources/Competition.swift
+++ b/Projects/Domain/Competition/Interface/Sources/Competition.swift
@@ -22,6 +22,8 @@ public struct Competition {
     
     public var verifications: [Vertification]
     
+    public let status: Status
+    
     public var info: [InfoKey: String]
     
     public var board: Board
@@ -30,12 +32,14 @@ public struct Competition {
         players: [Player],
         verifications: [Vertification],
         board: Board,
-        info: [InfoKey: String] = [:]
+        info: [InfoKey: String] = [:],
+        status: Status
     ) {
         self.players = players
         self.verifications = verifications
         self.board = board
         self.info = info
+        self.status = status
         self.board.update(pieces: createPieces(by: players))
     }
     
@@ -88,20 +92,48 @@ public extension Competition {
         case title
         case subtitle
     }
+    
+    enum Status: Equatable {
+        case created(hasOtherPlayer: Bool)
+        case started
+        case deleted
+        case pendingCompleted
+        case completed
+    }
+}
+
+public extension MissionStatus {
+    
+    func toCompetitionStatus(hasOtherPlayer: Bool) -> Competition.Status {
+        switch self {
+        case .pending, .created:
+            return .created(hasOtherPlayer: hasOtherPlayer)
+        case .canceled:
+            return .deleted
+        case .ongoing, .inProgress:
+            return .started
+        case .deleted:
+            return .deleted
+        case .pendingCompletion:
+            return .pendingCompleted
+        case .completed:
+            return .completed
+        }
+    }
 }
 
 public extension Mission {
     
-    func makeInfos(missionStatus: MissionStatus, progressCount: Int, myRank: Int) -> [Competition.InfoKey: String] {
-        switch missionStatus {
-        case .pending, .created, .canceled, .deleted:
+    func makeInfos(status: Competition.Status?, progressCount: Int, myRank: Int) -> [Competition.InfoKey: String] {
+        switch status {
+        case .created, .deleted, nil:
             let formatter = DateFormatter()
             formatter.dateFormat = "경쟁시작 M월 d일"
             return [
                 .title: formatter.string(from: startDate),
                 .subtitle: "해당일에 자동으로 경쟁이 시작돼요."
             ]
-        case .ongoing, .inProgress, .pendingCompletion, .completed:
+        case .started, .pendingCompleted, .completed:
             if !checkIsMissionDay || !checkIsMissionTime {
                 return [
                     .title: "꾸준하게 완수해봐요!",

--- a/Projects/Domain/Mission/Interface/Sources/MissionStatus.swift
+++ b/Projects/Domain/Mission/Interface/Sources/MissionStatus.swift
@@ -1,0 +1,42 @@
+//
+//  MissionStatus.swift
+//  DomainMissionInterface
+//
+//  Created by Haeseok Lee on 11/14/24.
+//
+
+import Foundation
+
+public enum MissionStatus: String {
+    case pending = "PENDING"
+    case ongoing = "ONGOING"
+    case created = "CREATED"
+    case canceled = "CANCELED"
+    case inProgress = "IN_PROGRESS"
+    case deleted = "DELETED"
+    case pendingCompletion = "PENDING_COMPLETION"
+    case completed = "COMPLETED"
+    
+    public init?(rawValue: String) {
+        switch rawValue {
+        case "PENDING":
+            self = .pending
+        case "ONGOING":
+            self = .ongoing
+        case "CREATED":
+            self = .created
+        case "CANCELED":
+            self = .canceled
+        case "IN_PROGRESS":
+            self = .inProgress
+        case "DELETED":
+            self = .deleted
+        case "PENDING_COMPLETION":
+            self = .pendingCompletion
+        case "COMPLETED":
+            self = .completed
+        default:
+            return nil
+        }
+    }
+}

--- a/Projects/Domain/Player/Interface/Sources/Serviceable/MissionMemberServiceable.swift
+++ b/Projects/Domain/Player/Interface/Sources/Serviceable/MissionMemberServiceable.swift
@@ -12,6 +12,8 @@ public protocol MissionMemberServiceable {
     var getMissionMembersMe: @Sendable () async throws -> MyMissionInfo { get }
     
     var getMissionMembersRank: @Sendable (_ missionId: Int) async throws -> MissionRank { get }
+    
+    var completeMission: @Sendable (_ missionId: Int) async throws -> Void { get }
 }
 
 public struct MyMissionInfo {
@@ -29,9 +31,11 @@ public struct MyMissionInfo {
     public struct MissionInfo {
         public let missionId: Int
         public let description: String
-        public init(missionId: Int, description: String) {
+        public let missionStatus: String
+        public init(missionId: Int, description: String, missionStatus: String) {
             self.missionId = missionId
             self.description = description
+            self.missionStatus = missionStatus
         }
     }
     

--- a/Projects/Feature/Home/Interface/Sources/Finish/FinishFeature.swift
+++ b/Projects/Feature/Home/Interface/Sources/Finish/FinishFeature.swift
@@ -7,11 +7,14 @@
 
 import Foundation
 import DomainPlayerInterface
+import DataRemoteInterface
+import DataRemote
 import ComposableArchitecture
 
 @Reducer
 public struct FinishFeature {
     
+    @Dependency(MissionMemberService.self) var missionMemberService
     @Dependency(\.dismiss) var dismiss
     
     @ObservableState
@@ -34,6 +37,8 @@ public struct FinishFeature {
         case didTapConfirmButton
         case didTapSettingButton
         case delegate(Delegate)
+        
+        case didCompleteMission(Result<Void, Error>)
     }
     
     public enum Delegate {
@@ -45,15 +50,23 @@ public struct FinishFeature {
         Reduce { state, action in
             switch action {
             case .didTapConfirmButton:
+                return .run { [missionId = state.missionId] send in
+                    await send(.didCompleteMission(Result {
+                        try await missionMemberService.completeMission(missionId)
+                    }))
+                }
+            case .didTapSettingButton:
+                return .send(.delegate(.didTapSettingButton))
+            case .delegate:
+                return .none
+            case .didCompleteMission(.success):
                 return .concatenate(
                     .run { _ in
                         await self.dismiss()
                     },
                     .send(.delegate(.didTapConfirmButton))
                 )
-            case .didTapSettingButton:
-                return .send(.delegate(.didTapSettingButton))
-            case .delegate:
+            case .didCompleteMission(.failure):
                 return .none
             }
         }

--- a/Projects/Feature/Home/Interface/Sources/Home/HomeFeature.swift
+++ b/Projects/Feature/Home/Interface/Sources/Home/HomeFeature.swift
@@ -79,7 +79,7 @@ public struct HomeFeature {
         case delegate(Delegate)
         
         case didFetchMyMissionInfo(Result<MyMissionInfo, Error>)
-        case didFetchVerificationAndMissionAndBoard(Result<(MissionVerification, Mission, MissionBoard, MissionRank), Error>)
+        case didFetchData(Result<(MissionVerification, Mission, MissionBoard, MissionRank), Error>)
         case didFetchVerificationInfo(Result<MissionVerification.VerificationInfo, Error>)
         case didFetchRank(Result<MissionRank, Error>)
     }
@@ -122,7 +122,7 @@ public struct HomeFeature {
                 
             case let .loadData(missionId):
                 return .run { send in
-                    await send(.didFetchVerificationAndMissionAndBoard(
+                    await send(.didFetchData(
                         Result {
                             async let mission = try missionService.getMissions(missionId)
                             async let board = try missionBoardService.getBoard(missionId)
@@ -133,7 +133,7 @@ public struct HomeFeature {
                     ))
                 }
             
-            case let .didFetchVerificationAndMissionAndBoard(.success((verification, mission, board, rank))):
+            case let .didFetchData(.success((verification, mission, board, rank))):
                 state.isLoading = false
                 state.mission = mission
                 
@@ -319,7 +319,7 @@ public struct HomeFeature {
                 state.isLoading = false
                 return .none
                 
-            case .didFetchVerificationAndMissionAndBoard(.failure):
+            case .didFetchData(.failure):
                 state.isLoading = false
                 return .none
                 

--- a/Projects/Feature/Home/Interface/Sources/Home/HomeFeature.swift
+++ b/Projects/Feature/Home/Interface/Sources/Home/HomeFeature.swift
@@ -180,8 +180,6 @@ public struct HomeFeature {
                         }
                     }
                 }
-                competition.sortPlayersByVerifiedAt()
-                competition.moveMeToFront()
                 
                 state.competition = competition
                 state.ctaButtonState = makeCTAButtonState(isMeCertificated: state.competition?.isMeVerified == true, mission: mission)

--- a/Projects/Feature/Home/Interface/Sources/Home/HomeFeature.swift
+++ b/Projects/Feature/Home/Interface/Sources/Home/HomeFeature.swift
@@ -24,6 +24,7 @@ public struct HomeFeature {
     public struct State {
         public var missionId: Int? = nil
         public var mission: Mission? = nil
+        public var missionStatus: MissionStatus? = nil
         public var me: Player? = nil
         public var competition: Competition? = nil
         public var movingPiece: Piece? = nil
@@ -71,9 +72,7 @@ public struct HomeFeature {
         case didSelectImages([UIImage])
         case didTapBlock(position: Position)
         case didFinishMoving(piece: Piece?)
-        case didFinishMission
         case loadData(missionId: Int)
-        case didLoadData(Competition.State)
         case destination(PresentationAction<Destination.Action>)
         case path(StackActionOf<Path>)
         case binding(BindingAction<State>)
@@ -112,10 +111,13 @@ public struct HomeFeature {
                     name: myMissionInfo.profile.nickname,
                     character: DomainUserInterface.Character(rawValue: myMissionInfo.profile.characterType) ?? .rabbit
                 )
-                guard let missionId = myMissionInfo.missions.first?.missionId else {
+                guard let latestMission = myMissionInfo.missions.last else {
                     return .send(.delegate(.didFinishMission))
                 }
+                let missionId = latestMission.missionId
+                let missionStatus = latestMission.missionStatus
                 state.missionId = missionId
+                state.missionStatus = MissionStatus(rawValue: missionStatus)
                 return .send(.loadData(missionId: missionId))
                 
             case let .loadData(missionId):
@@ -134,32 +136,39 @@ public struct HomeFeature {
             case let .didFetchVerificationAndMissionAndBoard(.success((verification, mission, board, rank))):
                 state.isLoading = false
                 state.mission = mission
-                let players: [Player] = board.missionBoards.flatMap(\.missionBoardMembers).map {
-                    Player(
-                        id: $0.nickname,
-                        pieceID: $0.nickname,
-                        name: $0.nickname,
-                        character: Character(rawValue: $0.characterType) ?? .rabbit,
-                        isMe: state.me?.name == $0.nickname
-                    )
-                }
-                let competitionState = mission.competitionState(hasOtherPlayers: players.count > 1)
-                let verifications = verification.missionVerifications.map {
-                    Vertification(id: $0.nickname, playerID: $0.nickname, imageURL: $0.imageUrl, verifiedAt: $0.verifiedAt)
-                }
+                
+                let missionStatus = state.missionStatus ?? .pending
                 var competition = Competition(
-                    players: players,
-                    verifications: verifications,
+                    players: board.missionBoards.flatMap(\.missionBoardMembers).map {
+                        Player(
+                            id: $0.nickname,
+                            pieceID: $0.nickname,
+                            name: $0.nickname,
+                            character: Character(rawValue: $0.characterType) ?? .rabbit,
+                            isMe: state.me?.name == $0.nickname
+                        )
+                    },
+                    verifications: verification.missionVerifications.map {
+                        Vertification(
+                            id: $0.nickname,
+                            playerID: $0.nickname,
+                            imageURL: $0.imageUrl,
+                            verifiedAt: $0.verifiedAt
+                        )
+                    },
                     board: Board(
                         theme: JejuIslandBoardTheme(),
                         events: board.missionBoards.map {
                             Event.reward(JejuRewardInfo(rawValue: $0.reward, position: Position(index: $0.number)))
                         },
                         totalBlockCount: mission.verificationDays + 1,
-                        isDisabled: competitionState != .started
+                        isDisabled: missionStatus != .inProgress
                     ),
-                    info: mission.makeInfos(competitionState: competitionState, progressCount: board.progressCount, myRank: rank.rank),
-                    state: competitionState
+                    info: mission.makeInfos(
+                        missionStatus: missionStatus,
+                        progressCount: board.progressCount,
+                        myRank: rank.rank
+                    )
                 )
                 
                 board.missionBoards.forEach { boardInfo in
@@ -176,25 +185,19 @@ public struct HomeFeature {
                 
                 state.competition = competition
                 state.ctaButtonState = makeCTAButtonState(isMeCertificated: state.competition?.isMeVerified == true, mission: mission)
-                return .send(.didLoadData(competitionState))
-                
-            case let .didLoadData(competitionState):
-                switch competitionState {
-                case .disabled:
+                switch missionStatus {
+                case .deleted:
                     state.destination = .missionDeleteAlert(MissionDeleteAlertFeature.State(missionId: state.missionId ?? 0))
                     return .none
                     
-                case .finished:
-                    return .send(.didFinishMission)
+                case .pendingCompletion:
+                    state.isLoading = true
+                    return .run { [missionId = state.missionId] send in
+                        await send(.didFetchRank( Result { try await missionMemberService.getMissionMembersRank(missionId ?? 0) } ))
+                    }
                     
                 default:
                     return .none
-                }
-                
-            case .didFinishMission:
-                state.isLoading = true
-                return .run { [missionId = state.missionId] send in
-                    await send(.didFetchRank( Result { try await missionMemberService.getMissionMembersRank(missionId ?? 0) } ))
                 }
                 
             case let .didFetchRank(.success(rankInfo)):
@@ -359,7 +362,9 @@ public extension HomeFeature {
             return .init(
                 isEnabled: mission.checkIsMissionTime,
                 info: info,
-                title: mission.checkIsMissionDay ? (mission.checkIsMissionTime ? "오늘 미션 인증하기" : "오늘 미션 인증 시간 마감") : "오늘은 미션일이 아니에요"
+                title: mission.checkIsMissionDay 
+                    ? (mission.checkIsMissionTime ? "오늘 미션 인증하기" : "오늘 미션 인증 시간 마감") 
+                    : "오늘은 미션일이 아니에요"
             )
         }
     }

--- a/Projects/Feature/Home/Interface/Sources/Home/HomeFeature.swift
+++ b/Projects/Feature/Home/Interface/Sources/Home/HomeFeature.swift
@@ -137,7 +137,7 @@ public struct HomeFeature {
                 state.isLoading = false
                 state.mission = mission
                 
-                let missionStatus = state.missionStatus ?? .pending
+                let status = state.missionStatus?.toCompetitionStatus(hasOtherPlayer: !board.isEmpty)
                 var competition = Competition(
                     players: board.missionBoards.flatMap(\.missionBoardMembers).map {
                         Player(
@@ -162,13 +162,14 @@ public struct HomeFeature {
                             Event.reward(JejuRewardInfo(rawValue: $0.reward, position: Position(index: $0.number)))
                         },
                         totalBlockCount: mission.verificationDays + 1,
-                        isDisabled: missionStatus != .inProgress
+                        isDisabled: status != .started
                     ),
                     info: mission.makeInfos(
-                        missionStatus: missionStatus,
+                        status: status,
                         progressCount: board.progressCount,
                         myRank: rank.rank
-                    )
+                    ),
+                    status: status ?? .created(hasOtherPlayer: false)
                 )
                 
                 board.missionBoards.forEach { boardInfo in
@@ -183,12 +184,12 @@ public struct HomeFeature {
                 
                 state.competition = competition
                 state.ctaButtonState = makeCTAButtonState(isMeCertificated: state.competition?.isMeVerified == true, mission: mission)
-                switch missionStatus {
+                switch status {
                 case .deleted:
                     state.destination = .missionDeleteAlert(MissionDeleteAlertFeature.State(missionId: state.missionId ?? 0))
                     return .none
                     
-                case .pendingCompletion:
+                case .pendingCompleted:
                     state.isLoading = true
                     return .run { [missionId = state.missionId] send in
                         await send(.didFetchRank( Result { try await missionMemberService.getMissionMembersRank(missionId ?? 0) } ))

--- a/Projects/Feature/Home/Interface/Sources/Home/Views/BlockView.swift
+++ b/Projects/Feature/Home/Interface/Sources/Home/Views/BlockView.swift
@@ -164,7 +164,7 @@ struct BlockView: View {
         .onTapGesture {
             store.send(.didTapBlock(position: block?.position ?? .zero))
         }
-        .disabled(store.missionStatus != .inProgress)
+        .disabled(store.competition?.status != .started)
     }
     
     func calcNextPoint(reader: GeometryProxy, movingDirection direction: DomainBoardInterface.Direction?) -> CGPoint {

--- a/Projects/Feature/Home/Interface/Sources/Home/Views/BlockView.swift
+++ b/Projects/Feature/Home/Interface/Sources/Home/Views/BlockView.swift
@@ -164,7 +164,7 @@ struct BlockView: View {
         .onTapGesture {
             store.send(.didTapBlock(position: block?.position ?? .zero))
         }
-        .disabled(store.competition?.state != .started)
+        .disabled(store.missionStatus != .inProgress)
     }
     
     func calcNextPoint(reader: GeometryProxy, movingDirection direction: DomainBoardInterface.Direction?) -> CGPoint {

--- a/Projects/Feature/Home/Interface/Sources/Home/Views/CompetitionContentView.swift
+++ b/Projects/Feature/Home/Interface/Sources/Home/Views/CompetitionContentView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import DomainMissionInterface
 import DomainPlayerInterface
 import DomainCompetitionInterface
 import SharedDesignSystem
@@ -69,7 +70,7 @@ struct CompetitionContentView: View {
                 .isHidden(!store.isLoading || isRefreshing, remove: true)
             
             if store.competition?.board.isDisabled == true {
-                NotStartedInfoView(me: store.competition?.me, competitionState: store.competition?.state ?? .disabled)
+                NotStartedInfoView(me: store.competition?.me, missionStatus: store.missionStatus)
                     .padding(.top, 167)
                     .allowsHitTesting(false)
             }
@@ -81,7 +82,7 @@ private struct NotStartedInfoView: View {
     
     let me: Player?
     
-    let competitionState: Competition.State
+    let missionStatus: MissionStatus?
     
     var body: some View {
         ZStack {
@@ -90,12 +91,12 @@ private struct NotStartedInfoView: View {
                 .frame(width: 240, height: 240)
                 .offset(y: 51)
             
-            if competitionState == .notStarted(hasOtherPlayer: true) {
+            if missionStatus == .ongoing {
                 SharedDesignSystemAsset.Images.notStartedInfoToolTip.swiftUIImage
                     .resizable()
                     .frame(width: 276, height: 96)
                     .offset(y: -110)
-            } else if competitionState == .notStarted(hasOtherPlayer: false) {
+            } else if missionStatus == .pending {
                 SharedDesignSystemAsset.Images.notStartedWarningToolTip.swiftUIImage
                     .resizable()
                     .frame(width: 276, height: 96)

--- a/Projects/Feature/Home/Interface/Sources/Home/Views/CompetitionContentView.swift
+++ b/Projects/Feature/Home/Interface/Sources/Home/Views/CompetitionContentView.swift
@@ -70,7 +70,7 @@ struct CompetitionContentView: View {
                 .isHidden(!store.isLoading || isRefreshing, remove: true)
             
             if store.competition?.board.isDisabled == true {
-                NotStartedInfoView(me: store.competition?.me, missionStatus: store.missionStatus)
+                NotStartedInfoView(me: store.competition?.me, status: store.competition?.status)
                     .padding(.top, 167)
                     .allowsHitTesting(false)
             }
@@ -82,7 +82,7 @@ private struct NotStartedInfoView: View {
     
     let me: Player?
     
-    let missionStatus: MissionStatus?
+    let status: Competition.Status?
     
     var body: some View {
         ZStack {
@@ -91,12 +91,12 @@ private struct NotStartedInfoView: View {
                 .frame(width: 240, height: 240)
                 .offset(y: 51)
             
-            if missionStatus == .ongoing {
+            if status == .created(hasOtherPlayer: true) {
                 SharedDesignSystemAsset.Images.notStartedInfoToolTip.swiftUIImage
                     .resizable()
                     .frame(width: 276, height: 96)
                     .offset(y: -110)
-            } else if missionStatus == .pending {
+            } else if status == .created(hasOtherPlayer: false) {
                 SharedDesignSystemAsset.Images.notStartedWarningToolTip.swiftUIImage
                     .resizable()
                     .frame(width: 276, height: 96)

--- a/Projects/Feature/Home/Interface/Sources/Home/Views/HomeNavigationBarView.swift
+++ b/Projects/Feature/Home/Interface/Sources/Home/Views/HomeNavigationBarView.swift
@@ -33,7 +33,7 @@ struct HomeNavigationBarView: View {
                             store.send(.didTapMissionInfoGuideToolTip)
                         }
                         .isHidden(
-                            store.isMissionInfoGuideToolTipShowed || store.competition?.state != .notStarted(hasOtherPlayer: true),
+                            store.isMissionInfoGuideToolTipShowed || store.missionStatus != .ongoing,
                             remove: true
                         )
                 }
@@ -60,7 +60,7 @@ struct HomeNavigationBarView: View {
                                 store.send(.didTapInvitationInfoToolTip)
                             }
                             .isHidden(
-                                store.isInvitationGuideToolTipShowed || store.competition?.state != .notStarted(hasOtherPlayer: false) || !store.isMeHost,
+                                store.isInvitationGuideToolTipShowed || store.missionStatus != .pending || !store.isMeHost,
                                 remove: true
                             )
                     }

--- a/Projects/Feature/Home/Interface/Sources/Home/Views/HomeNavigationBarView.swift
+++ b/Projects/Feature/Home/Interface/Sources/Home/Views/HomeNavigationBarView.swift
@@ -33,7 +33,7 @@ struct HomeNavigationBarView: View {
                             store.send(.didTapMissionInfoGuideToolTip)
                         }
                         .isHidden(
-                            store.isMissionInfoGuideToolTipShowed || store.missionStatus != .ongoing,
+                            store.isMissionInfoGuideToolTipShowed || store.competition?.status != .created(hasOtherPlayer: true),
                             remove: true
                         )
                 }
@@ -60,7 +60,7 @@ struct HomeNavigationBarView: View {
                                 store.send(.didTapInvitationInfoToolTip)
                             }
                             .isHidden(
-                                store.isInvitationGuideToolTipShowed || store.missionStatus != .pending || !store.isMeHost,
+                                store.isInvitationGuideToolTipShowed || store.competition?.status != .created(hasOtherPlayer: false) || !store.isMeHost,
                                 remove: true
                             )
                     }

--- a/Projects/Feature/Home/Interface/Sources/Home/Views/PlayerView.swift
+++ b/Projects/Feature/Home/Interface/Sources/Home/Views/PlayerView.swift
@@ -23,7 +23,7 @@ struct PlayerView: View {
     var body: some View {
         VStack(alignment: .center, spacing: 6) {
             ZStack(alignment: .top) {
-                let shouldDisabled = !player.isMe && (store.missionStatus == .ongoing || verification?.isVerified == false)
+                let shouldDisabled = !player.isMe && (store.competition?.status == .created(hasOtherPlayer: true) || verification?.isVerified == false)
                 Button(action: {
                     store.send(.didTapPlayer(player: player))
                 }) {

--- a/Projects/Feature/Home/Interface/Sources/Home/Views/PlayerView.swift
+++ b/Projects/Feature/Home/Interface/Sources/Home/Views/PlayerView.swift
@@ -23,8 +23,7 @@ struct PlayerView: View {
     var body: some View {
         VStack(alignment: .center, spacing: 6) {
             ZStack(alignment: .top) {
-                let shouldDisabled = !player.isMe 
-                    && (store.competition?.state == .notStarted(hasOtherPlayer: true) || verification?.isVerified == false)
+                let shouldDisabled = !player.isMe && (store.missionStatus == .ongoing || verification?.isVerified == false)
                 Button(action: {
                     store.send(.didTapPlayer(player: player))
                 }) {

--- a/Projects/Feature/Home/Interface/Sources/Home/Views/StoryView.swift
+++ b/Projects/Feature/Home/Interface/Sources/Home/Views/StoryView.swift
@@ -15,7 +15,7 @@ struct StoryView: View {
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 15) {
-                ForEach(store.competition?.players ?? []) { player in
+                ForEach(store.competition?.sortedPlayersByVerification ?? []) { player in
                     PlayerView(player: player, verification: store.competition?.findVerification(by: player.id), store: store)
                 }
             }


### PR DESCRIPTION
### 🏗️ 구현사항

- 기존에 미션상태를 클라에서 판단하던 로직을 제거하고 서버 api로 마이그레이션 했습니다
- 미션완료화면에서 확인버튼을 누르면 complete mission api를 호출해서 미션 상태가 pendingComplete -> complete로 바뀌게 합니다
- Story뷰 순서를 클라에서 정렬하지 않고 서버에서 내려주는 순서로 변경했습니다

### ✅ 체크사항


기존 동작과 달라지지 않았는지 


 ---------
- Resolved: #86 
- Resolved: #89 
