### PR TITLE
feat: 스토리 view 방어로직 작성 및 버그수정

### DIFF
--- a/Projects/Domain/Competition/Interface/Sources/Vertification.swift
+++ b/Projects/Domain/Competition/Interface/Sources/Vertification.swift
@@ -24,21 +24,25 @@ public struct Vertification {
     }
     
     public var isViewed: Bool {
-        verifiedAt != nil
+        viewedAt != nil
     }
     
     public var verifiedAt: Date?
+    
+    public var viewedAt: Date?
     
     public init(
         id: Int?,
         playerID: PlayerID,
         imageURL: String? = nil,
-        verifiedAt: Date? = nil
+        verifiedAt: Date? = nil,
+        viewedAt: Date? = nil
     ) {
         self.id = id
         self.playerID = playerID
         self.imageURL = imageURL
         self.verifiedAt = verifiedAt
+        self.viewedAt = viewedAt
     }
     
     public mutating func update(imageURL: String, verifiedAt: Date?) {

--- a/Projects/Feature/Home/Interface/Sources/Home/HomeFeature.swift
+++ b/Projects/Feature/Home/Interface/Sources/Home/HomeFeature.swift
@@ -154,7 +154,8 @@ public struct HomeFeature {
                             id: $0.missionVerificationId,
                             playerID: $0.nickname,
                             imageURL: $0.imageUrl,
-                            verifiedAt: $0.verifiedAt
+                            verifiedAt: $0.verifiedAt,
+                            viewedAt: $0.viewedAt
                         )
                     },
                     board: Board(
@@ -221,7 +222,7 @@ public struct HomeFeature {
             case let .didTapPlayer(player):
                 guard let verification = state.competition?.findVerification(by: player.id), verification.isVerified else { return .none }
                 state.destination = .imageDetail(ImageDetailFeature.State(player: player, verifiedAt: verification.verifiedAt ?? Date.now, imageURL: verification.imageURL))
-                guard let verificationId = verification.id else { return .none }
+                guard !verification.isViewed, let verificationId = verification.id else { return .none }
                 return .run { send in
                     await send(.didViewVerification(
                         Result {
@@ -288,6 +289,9 @@ public struct HomeFeature {
                     
                 case .presented(.missionDeleteAlert(.delegate(.didDeleteMission))):
                     return .send(.delegate(.didDeleteMission))
+                    
+                case .presented(.imageDetail(.delegate(.didTapCloseButton))):
+                    return .send(.didRefresh)
                     
                 case .presented(_):
                     return .none

--- a/Projects/Feature/Home/Interface/Sources/ImageDetail/ImageDetailFeature.swift
+++ b/Projects/Feature/Home/Interface/Sources/ImageDetail/ImageDetailFeature.swift
@@ -35,15 +35,25 @@ public struct ImageDetailFeature {
     
     public enum Action {
         case didTapCloseButton
+        case delegate(Delegate)
+    }
+    
+    public enum Delegate {
+        case didTapCloseButton
     }
     
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
             case .didTapCloseButton:
-                return .run { _ in
-                    await self.dismiss()
-                }
+                return .concatenate(
+                    .send(.delegate(.didTapCloseButton)),
+                    .run { _ in
+                        await self.dismiss()
+                    }
+                )
+            case .delegate:
+                return .none
             }
         }
     }


### PR DESCRIPTION
### 🏗️ 구현사항

- 한번본 스토리는 view verification api 를 호출하지 않게 방어로직을 작성했습니다
- isViewed가 잘못 구현된 이슈를 수정했습니다
- 미션 인증 확인 화면을 한번 확인한 후에 홈으로 돌아왔을때 홈이 다시 리프레시 되도록 수정했습니다



 ---------
- Resolved: #94 
