### PR TITLE
feature: 중복인증 클라 방어로직 

### DIFF
--- a/Projects/Feature/Home/Interface/Sources/Home/HomeFeature.swift
+++ b/Projects/Feature/Home/Interface/Sources/Home/HomeFeature.swift
@@ -278,10 +278,24 @@ public struct HomeFeature {
                 switch action {
                 case .dismiss:
                     return .none
-                case .presented(.imageUpload(.delegate(.didFinishImageUpload))):
+                    
+                case .presented(.imageUpload(.delegate(.didFinishImageUpload(.success)))):
                     guard let myPiece = state.competition?.myPiece else { return .none }
                     state.movingPiece = myPiece
                     state.competition?.board.remove(piece: myPiece)
+                    return .none
+                    
+                case .presented(.imageUpload(.delegate(.didFinishImageUpload(.failure)))):
+                    guard let mission = state.mission else { return .none }
+                    state.ctaButtonState = makeCTAButtonState(isMeCertificated: state.competition?.isMeVerified == true, mission: mission)
+                    return .none
+                    
+                case .presented(.imageUpload(.delegate(.didStartImageUpload))):
+                    state.ctaButtonState = CTAButtonState(
+                        info: state.ctaButtonState.info,
+                        title: "",
+                        status: .loading
+                    )
                     return .none
                     
                 case .presented(.verificationResult(.delegate(.didTapCloseButton))):
@@ -369,10 +383,18 @@ private extension HomeFeature {
 public extension HomeFeature {
     
     struct CTAButtonState {
-        static let `default`: Self = .init(isEnabled: false, info: "", title: "")
-        let isEnabled: Bool
+        enum Status {
+            case enabled
+            case disabled
+            case loading
+            var isEnabled: Bool { self == .enabled }
+            var isDisabled: Bool { self == .disabled }
+            var isLoading: Bool { self == .loading }
+        }
+        static let `default`: Self = .init(info: "", title: "", status: .enabled)
         let info: String
         let title: String
+        let status: Status
     }
     
     func makeCTAButtonState(isMeCertificated: Bool, mission: Mission) -> CTAButtonState {
@@ -380,17 +402,17 @@ public extension HomeFeature {
         switch isMeCertificated {
         case true:
             return .init(
-                isEnabled: false,
                 info: info,
-                title: "오늘 미션 인증 완료!"
+                title: "오늘 미션 인증 완료!",
+                status: .disabled
             )
         case false:
             return .init(
-                isEnabled: mission.checkIsMissionTime,
                 info: info,
                 title: mission.checkIsMissionDay 
                     ? (mission.checkIsMissionTime ? "오늘 미션 인증하기" : "오늘 미션 인증 시간 마감") 
-                    : "오늘은 미션일이 아니에요"
+                    : "오늘은 미션일이 아니에요",
+                status: mission.checkIsMissionTime ? .enabled : .disabled
             )
         }
     }

--- a/Projects/Feature/Home/Interface/Sources/Home/Views/HomeBottomView.swift
+++ b/Projects/Feature/Home/Interface/Sources/Home/Views/HomeBottomView.swift
@@ -27,22 +27,32 @@ struct HomeBottomView: View {
             .padding(.top, 16)
             .padding(.bottom, 6)
             
-            PhotoPickerView(selectedImages: $store.selectedImages.sending(\.didSelectImages), maxSelectedCount: 1) {
+            PhotoPickerView(
+                selectedImages: $store.selectedImages.sending(\.didSelectImages),
+                maxSelectedCount: 1
+            ) {
                 Text(store.ctaButtonState.title)
                     .font(.pretendard(kind: .body_lg, type: .bold))
                     .foregroundColor(SharedDesignSystemAsset.Colors.white.swiftUIColor)
                     .frame(height: 60)
                     .frame(maxWidth: .infinity)
                     .background(
-                        store.ctaButtonState.isEnabled
+                        store.ctaButtonState.status.isEnabled
                         ? SharedDesignSystemAsset.Colors.orange.swiftUIColor
                         : SharedDesignSystemAsset.Colors.disabled.swiftUIColor
                     )
                     .cornerRadius(30)
+                    .overlay {
+                        VStack(alignment: .center, spacing: 0) {
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle())
+                                .isHidden(!store.ctaButtonState.status.isLoading, remove: true)
+                        }
+                    }
             }
             .padding(.horizontal, HomeView.Constant.horizontalPadding)
             .padding(.bottom, 36)
-            .disabled(!store.ctaButtonState.isEnabled)
+            .disabled(store.ctaButtonState.status.isDisabled)
         }
         .background(.ultraThinMaterial)
         .cornerRadius(20, corners: [.topLeft, .topRight])

--- a/Projects/Feature/Home/Interface/Sources/ImageUpload/ImageUploadFeature.swift
+++ b/Projects/Feature/Home/Interface/Sources/ImageUpload/ImageUploadFeature.swift
@@ -25,6 +25,7 @@ public struct ImageUploadFeature {
         public let updatedDate: Date
         public let selectedImage: UIImage
         public var isLoading: Bool = false
+        public var isButtonDisabled: Bool = false
         
         public var formatedDate: String {
             DateFormatter.yearMonthDayFormatter.string(from: updatedDate)
@@ -46,7 +47,8 @@ public struct ImageUploadFeature {
     }
     
     public enum Delegate {
-        case didFinishImageUpload
+        case didStartImageUpload
+        case didFinishImageUpload(Result<Void, Error>)
     }
     
     public var body: some ReducerOf<Self> {
@@ -54,18 +56,22 @@ public struct ImageUploadFeature {
             switch action {
             case .didTapUploadButton:
                 state.isLoading = true
-                return .run { [
-                    missionId = state.missionId, 
-                    selectedImage = state.selectedImage
-                ] send in
-                    await send(.didFinishImageUpload(
-                        Result {
-                            if let data = selectedImage.jpegData(compressionQuality: 0.5) {
-                                return try await verificationService.postVerificationsMe(missionId, data)
+                state.isButtonDisabled = true
+                return .concatenate(
+                    .send(.delegate(.didStartImageUpload)),
+                    .run { [
+                        missionId = state.missionId,
+                        selectedImage = state.selectedImage
+                    ] send in
+                        await send(.didFinishImageUpload(
+                            Result {
+                                if let data = selectedImage.jpegData(compressionQuality: 0.5) {
+                                    return try await verificationService.postVerificationsMe(missionId, data)
+                                }
                             }
-                        }
-                    ))
-                }
+                        ))
+                    }
+                )
             case .didTapCloseButton:
                 return .run { _ in
                     await self.dismiss()
@@ -73,14 +79,15 @@ public struct ImageUploadFeature {
             case .didFinishImageUpload(.success):
                 state.isLoading = false
                 return .concatenate(
-                    .send(.delegate(.didFinishImageUpload)),
+                    .send(.delegate(.didFinishImageUpload(.success(())))),
                     .run { _ in
                         await self.dismiss()
                     }
                 )
             case .didFinishImageUpload(.failure):
                 state.isLoading = false
-                return .none
+                state.isButtonDisabled = false
+                return .send(.delegate(.didFinishImageUpload(.failure(NSError()))))
             case .delegate:
                 return .none
             }

--- a/Projects/Feature/Home/Interface/Sources/ImageUpload/ImageUploadView.swift
+++ b/Projects/Feature/Home/Interface/Sources/ImageUpload/ImageUploadView.swift
@@ -77,11 +77,16 @@ public struct ImageUploadView: View {
                     .foregroundColor(SharedDesignSystemAsset.Colors.white.swiftUIColor)
                     .frame(height: 60)
                     .frame(maxWidth: .infinity)
-                    .background(SharedDesignSystemAsset.Colors.orange.swiftUIColor)
+                    .background(
+                        store.state.isButtonDisabled
+                        ? SharedDesignSystemAsset.Colors.disabled.swiftUIColor
+                        : SharedDesignSystemAsset.Colors.orange.swiftUIColor
+                    )
                     .cornerRadius(30)
             }
             .padding(.horizontal, 24)
             .padding(.bottom, safeAreaInsets.bottom)
+            .disabled(store.state.isButtonDisabled)
         }
         .background(SharedDesignSystemAsset.Colors.white.swiftUIColor)
     }


### PR DESCRIPTION
### 🏗️ 구현사항

- 중복인증을 하지 못하도록 클라에 방어로직을 작성했습니다
- 인증화면 인증 버튼 탭 
- 인증 중 : 인증버튼 disabled, 홈 인증버튼 로딩처리 
- 인증 완료 : 홈 인증버튼 상태변경 



 ---------
- Resolved: #97 
