### PR TITLE
feat: 네비게이션 아이템 isHidden 수정

### DIFF
--- a/Projects/Domain/Competition/Interface/Sources/Competition.swift
+++ b/Projects/Domain/Competition/Interface/Sources/Competition.swift
@@ -102,6 +102,18 @@ public extension Competition {
     }
 }
 
+public extension Competition.Status {
+    
+    var isCreated: Bool {
+        switch self {
+        case .created:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
 public extension MissionStatus {
     
     func toCompetitionStatus(hasOtherPlayer: Bool) -> Competition.Status {

--- a/Projects/Feature/Home/Interface/Sources/Home/Views/HomeNavigationBarView.swift
+++ b/Projects/Feature/Home/Interface/Sources/Home/Views/HomeNavigationBarView.swift
@@ -32,10 +32,7 @@ struct HomeNavigationBarView: View {
                         .onTapGesture {
                             store.send(.didTapMissionInfoGuideToolTip)
                         }
-                        .isHidden(
-                            store.isMissionInfoGuideToolTipShowed || store.competition?.status != .created(hasOtherPlayer: true),
-                            remove: true
-                        )
+                        .isHidden(store.isMissionInfoGuideToolTipShowed, remove: true)
                 }
                 
                 Spacer()
@@ -49,18 +46,17 @@ struct HomeNavigationBarView: View {
                             .frame(width: 28, height: 28)
                             .foregroundColor(SharedDesignSystemAsset.Colors.gray1.swiftUIColor)
                     }
-                    .isHidden(store.competition?.board.isDisabled == false || !store.isMeHost, remove: true)
+                    .isHidden(!((store.competition?.status.isCreated) ?? false), remove: true)
                     .overlay {
                         SharedDesignSystemAsset.Images.invitationCodeGuideToolTip.swiftUIImage
                             .resizable()
                             .frame(width: 161, height: 72)
                             .offset(x: -42, y: 50)
-                            
                             .onTapGesture {
                                 store.send(.didTapInvitationInfoToolTip)
                             }
                             .isHidden(
-                                store.isInvitationGuideToolTipShowed || store.competition?.status != .created(hasOtherPlayer: false) || !store.isMeHost,
+                                store.isInvitationGuideToolTipShowed || !((store.competition?.status.isCreated) ?? false),
                                 remove: true
                             )
                     }


### PR DESCRIPTION
### 🏗️ 구현사항


- 미션을 생성했을때 미션 초대 코드가 방장 포함 모든 사람들에게 노출하도록 수정했습니다
- 미션생성시 미션정보 버튼 노출되도록 수정했습니다




 ---------
- Resolved: #99 
